### PR TITLE
allow base-4.8

### DIFF
--- a/aws-kinesis-client.cabal
+++ b/aws-kinesis-client.cabal
@@ -40,7 +40,7 @@ library
                        Aws.Kinesis.Client.Internal.Queue.Chunk
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <5.0,
                        base-unicode-symbols,
                        aeson >=0.8,
                        aws >=0.10.5,
@@ -78,7 +78,7 @@ executable kinesis-cli
     hs-source-dirs: cli
     main-is: CLI.hs
     other-modules:     CLI.Options
-    build-depends:     base >=4.7 && <4.8,
+    build-depends:     base >=4.7 && <5.0,
                        base-unicode-symbols,
                        aeson >=0.8,
                        aws >=0.10.5,


### PR DESCRIPTION
Also the dependency on base of version 0.4.0.0 on Hackage should be relaxed to allow base-4.8.
