### PR TITLE
Fix for #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v0.4.0.1
+
+This release fixes a bug in the Consumer where a saved state could get
+clobbered in case no further records were found at the restored point on a
+shard.
+
 ### v0.4.0.0
 
 This release contains breaking changes.

--- a/aws-kinesis-client.cabal
+++ b/aws-kinesis-client.cabal
@@ -1,5 +1,5 @@
 name:                aws-kinesis-client
-version:             0.4.0.0
+version:             0.4.0.1
 synopsis:            A producer & consumer client library for AWS Kinesis
 description:
     This package provides a Producer client for bulk-writing messages to a
@@ -84,7 +84,7 @@ executable kinesis-cli
                        aws >=0.10.5,
                        aws-general >=0.2.1,
                        aws-kinesis >=0.1.4,
-                       aws-kinesis-client >=0.4.0.0,
+                       aws-kinesis-client >=0.4.0.1,
                        conduit >=1.2.3.1,
                        http-conduit >=2.1.5,
                        kan-extensions >=4.2,

--- a/cli/CLI/Options.hs
+++ b/cli/CLI/Options.hs
@@ -216,5 +216,5 @@ parserInfo =
   info (helper ⊛ optionsParser) $
     fullDesc
     ⊕ progDesc "Fetch a given number of records from a Kinesis stream; unlike the standard command line utilities, this interface is suitable for use with a sharded stream. If you both specify a saved stream state to be restored and an iterator type, the latter will be used on any shards which are not contained in the saved state. Minimally, you must specify your AWS credentials, a stream name, and an optional limit & timeout."
-    ⊕ header "The Kinesis Consumer CLI v0.2.0.3"
+    ⊕ header "The Kinesis Consumer CLI v0.4.0.1"
 

--- a/src/Aws/Kinesis/Client/Consumer/Internal.hs
+++ b/src/Aws/Kinesis/Client/Consumer/Internal.hs
@@ -113,7 +113,7 @@ updateStreamState ConsumerKit{..} state = do
 
     liftIO ∘ atomically $ do
       iteratorVar ← newTVar $ Just it
-      sequenceNumberVar ← newTVar Nothing
+      sequenceNumberVar ← newTVar startingSequenceNumber
       return $ makeShardState shardShardId iteratorVar sequenceNumberVar
 
   return ∘ CR.nub $ CR.append shardStates state


### PR DESCRIPTION
Quoting from #29:

> What is happening is the following: if there was a saved state, but no records are found at that point on the shard, the state got wiped out and replaced with an empty one on the next save.

This issue could happen if you restore a saved stream state, but there are not yet any more records on the shard after the bookmark. In this case, the next saved state would lose the bookmark for that shard.

The solution is to mark a shard's last sequence number pre-emptively, in case we are not able to retrieve further records (which would supersede the restored state) at this time.
